### PR TITLE
Update Community.VisualStudio.Toolkit.DependencyInjection.Core.17.0.c…

### DIFF
--- a/src/Core/17.0/Community.VisualStudio.Toolkit.DependencyInjection.Core.17.0.csproj
+++ b/src/Core/17.0/Community.VisualStudio.Toolkit.DependencyInjection.Core.17.0.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Community.VisualStudio.Toolkit.17" Version="17.0.430" />
+    <PackageReference Include="Community.VisualStudio.Toolkit.17" Version="17.0.482" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
Bump Community.VisualStudio.Toolkit.17 to 17.0.482

Using the DI lib requires an older version of the toolkit which has this issue:
https://github.com/VsixCommunity/Community.VisualStudio.Toolkit/issues/322