### PR TITLE
Update  Community.VisualStudio.Toolkit.DependencyInjection.Core.17.0.…

### DIFF
--- a/src/Core/17.0/Community.VisualStudio.Toolkit.DependencyInjection.Core.17.0.csproj
+++ b/src/Core/17.0/Community.VisualStudio.Toolkit.DependencyInjection.Core.17.0.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Community.VisualStudio.Toolkit.17" Version="17.0.482" />
+    <PackageReference Include="Community.VisualStudio.Toolkit.17" Version="17.0.522" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
…csproj

Bump the dependency on the Community Toolkit to 17.0.522 without this change if someone tries to use the latest version of Community Toolkit assembly cannot be properly resolved and loading of the package will fail.