### PR TITLE
Update Community.VisualStudio.Toolkit.DependencyInjection.Core.17.0.c…

### DIFF
--- a/src/Core/17.0/Community.VisualStudio.Toolkit.DependencyInjection.Core.17.0.csproj
+++ b/src/Core/17.0/Community.VisualStudio.Toolkit.DependencyInjection.Core.17.0.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Community.VisualStudio.Toolkit.17" Version="17.0.522" />
+    <PackageReference Include="Community.VisualStudio.Toolkit.17" Version="17.0.527" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
Bumped Community.VisualStudio.Toolkit.17 dependency to its latest version 17.0.527.

In an extension that is using Community.VisualStudio.Toolkit.DependencyInjection, updating Community.VisualStudio.Toolkit nuget to its latest version will stop your extension from loading due to its dependency on the previous version.

